### PR TITLE
Better tables

### DIFF
--- a/docs/reference/authorizer/mainnet.md
+++ b/docs/reference/authorizer/mainnet.md
@@ -1,3 +1,7 @@
+---
+pageClass: wide-content
+---
+
 # Mainnet Authorizer Permissions
 
 ### Last generated on 2023-05-10

--- a/theme/src/client/styles/markdown.scss
+++ b/theme/src/client/styles/markdown.scss
@@ -6,8 +6,20 @@
 }
 
 table {
+  width: 100%;
+  table-layout: fixed;
   td {
     background: none;
+  }
+  td, th {
+    font-size: 14px;    
+    word-break: break-word; 
+    overflow-wrap: break-word; 
+    min-width: 140px;
+    vertical-align: top;
+  }
+  td:first-child {
+    min-width: 200px;
   }
 }
 

--- a/theme/src/client/styles/page.scss
+++ b/theme/src/client/styles/page.scss
@@ -11,6 +11,12 @@
   }
 }
 
+.wide-content .page {
+  .theme-default-content {
+    max-width: 1800px;
+  }
+}
+
 .page-hero {
   min-height: 5rem;
   height: 10rem;


### PR DESCRIPTION

**Problem:** 
Currently tables are not displaying well when constricted to the narrower default content layout. 

**Solution:** 
1. CSS tweaks to tables to make them fit better, and break up longer words to prevent overflow issues
2. Add a new site wide class for markdown files for wider content. For example, add this front matter to any page that requires a wider layout than the default narrow layout:

```
---
pageClass: wide-content
---
```

Example table. Note, these tables are usually script generated, so they will need to include the new frontmatter to get the wider layout.

![tables](https://github.com/balancer/docs/assets/1121139/8f33a751-b8a3-439f-9d00-fb3dbb9481a6)




