### PR TITLE
fix: use deprecate instead of obsolete

### DIFF
--- a/docs/concepts/pools/composable-stable.md
+++ b/docs/concepts/pools/composable-stable.md
@@ -9,7 +9,7 @@ references:
 
 ::: info Predecessors
 
-**Composable Stable Pools** are a superset of all previous Stable-type pools (Stable Pools, MetaStable Pools, StablePhantom Pools, and StablePool v2) and therefore obsolete all previous pools.
+**Composable Stable Pools** are a superset of all previous Stable-type pools (Stable Pools, MetaStable Pools, StablePhantom Pools, and StablePool v2) and therefore deprecate all previous pools.
 :::
 
 ## Overview


### PR DESCRIPTION
obsolete is an adjective not a verb. Therefore "deprecate" or "make all previous pools obsolete" would be a more grammatically correct and suitable word for this situation. 