### PR TITLE
fix broken guide link

### DIFF
--- a/docs/sdk/technical-reference/pricing.md
+++ b/docs/sdk/technical-reference/pricing.md
@@ -2,7 +2,7 @@
 order: 4
 guides:
   - details: Get Spot Price of Pool
-    link: /guides/swaps/get-spot-price.md
+    link: /guides/arbitrageurs/get-spot-price.md
 ---
 
 # Pricing


### PR DESCRIPTION
Hi ! Unless I'm mistaken, there's a broken link in the "Guides" section (right hand side) of the [SDK's Pricing page](https://docs.balancer.fi/sdk/technical-reference/pricing.html).