### PR TITLE
Update pool-exits.md

### DIFF
--- a/docs/reference/joins-and-exits/pool-exits.md
+++ b/docs/reference/joins-and-exits/pool-exits.md
@@ -109,10 +109,10 @@ enum ExitKind {
 
 - **Single Asset Exit** (`EXACT_BPT_IN_FOR_ONE_TOKEN_OUT`)
   - User sends a precise quantity of BPT, and receives an estimated but unknown (computed at run time) quantity of a single token.
-- **Proportional Exit** (`EXACT_BPT_IN_FOR_TOKENS_OUT`)
-  - User sends a precise quantity of BPT, and receives an estimated but unknown (computed at run time) quantities of all tokens.
-- **Custom Exit** (`BPT_IN_FOR_EXACT_TOKENS_OUT`)
-  - User sends an estimated but unknown (computed at run time) quantity of BPT, and receives precise quantities of specified tokens.
+- **Proportional Exit** (`BPT_IN_FOR_EXACT_TOKENS_OUT`)
+  - User sends a precise quantity of BPT, and receives an estimated but unknown (computed at run time) quantities of specified tokens.
+- **Custom Exit** (`EXACT_BPT_IN_FOR_TOKENS_OUT`)
+  - User sends an estimated but unknown (computed at run time) quantity of BPT, and receives precise quantities of all tokens.
 
 #### Encoding
 
@@ -123,11 +123,11 @@ enum ExitKind {
     - `[EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, bptAmountIn, exitTokenIndex]`
 - Proportional Exit
   - userData ABI
-    - `['uint256', 'uint256']`
-  - userData
-    - `[EXACT_BPT_IN_FOR_TOKENS_OUT, bptAmountIn]`
-- Custom Exit
-  - userData ABI
     - `['uint256', 'uint256[]', 'uint256']`
   - userData
     - `[BPT_IN_FOR_EXACT_TOKENS_OUT, amountsOut, maxBPTAmountIn]`
+- Custom Exit
+  - userData ABI
+    - `['uint256', 'uint256']`
+  - userData
+    - `[EXACT_BPT_IN_FOR_TOKENS_OUT, bptAmountIn]`


### PR DESCRIPTION
Fixed Encoding section for Proportional and Custom Exits.

Determined and confirmed through testing that these two definitions were mixed up. See the below transactions on Metis Goerli and note the `userData` fields  for further proof. Contract addresses also included for reference.

Proportional Exit (returning all 3 specified tokens back from estimated BPT amount): https://goerli.explorer.metisdevops.link/tx/0x9b9e873461007d2fb0950d24a22eff87cfb4647c1f5d89c19867d1551bec1463

Proportional Exit (returning only 2 specified tokens back from estimated BPT amount): https://goerli.explorer.metisdevops.link/tx/0x2ea019ecc160448689100f3d46bbccba7b9eece05d579447d390e0978e157a24

Custom Exit (returning estimated amounts of all 3 tokens from exact BPT amount): https://goerli.explorer.metisdevops.link/tx/0x21af9d0f17773d134e9384098864844c11baf35782577af14058357fce10b1be

Vault: https://goerli.explorer.metisdevops.link/address/0xAd8Ab48eD57F35dCD2a0c67Bfc5c91d35bF1C5b4
Tri Stable ComposableStablePoolV5 (containing mock ERCs for USDC/USDT/DAI): https://goerli.explorer.metisdevops.link/address/0xBf49cC8510040B71AF73bD4A9fcEB70EBDA0C108