### PR TITLE
FIX: update tooling page links

### DIFF
--- a/docs/.vuepress/components/Tools.vue
+++ b/docs/.vuepress/components/Tools.vue
@@ -99,7 +99,7 @@ const calculatorsAndDApps = [
     icon: '/images/logo-light.svg',
     details:
       'veBAL, Impermanent Loss and Price Impact Calculators - created by Xeonus and Zen Dragon',
-    link: 'https://balancer.tools/veBAL',
+    link: 'https://balancer-legacy.defilytica.tools/veBAL',
   },
   {
     title: 'veBAL Gauge Multivoter',


### PR DESCRIPTION
- add new [defilytica.tools](https://balancer-legacy.defilytica.tools/veBAL) domain
- balancer.tools does not work anymore and has been disabled