### PR TITLE
Fix typo: 'contruct' to 'construct' in README.md/docs page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ features:
     link: /guides
   - title: Boosted Pools
     icon: /images/quick-link-boosted.svg
-    details: Learn how they work and how to contruct them
+    details: Learn how they work and how to construct them
     link: /concepts/pools/boosted.html
   - title: Liquidity Bootstrapping Pools
     icon: /images/quick-link-lbp.svg


### PR DESCRIPTION
### Fix Typo in README.md/docs Page

**Details:**
Corrected a typo in the README.md file from "contruct" to "construct".

**Files Changed:**
- /workspaces/docs/docs/README.md
![image](https://github.com/balancer/docs/assets/161780994/46bf5a68-7453-4798-8ee2-949794d10842)
